### PR TITLE
Allow Berry to build on OpenBSD.

### DIFF
--- a/imagemetadata.cpp
+++ b/imagemetadata.cpp
@@ -18,7 +18,7 @@
 
 #include "imagemetadata.h"
 
-#ifdef Q_OS_LINUX
+#if defined(Q_OS_LINUX) || defined(Q_OS_UNIX)
 #include <exiv2/image.hpp>
 #endif
 


### PR DESCRIPTION
This will also let Berry build on the other BSDs.
I don't own any Mac OS X machines, so don't know if it will interfere with the Mac OS X build.
Tested with OpenBSD/i386.
