### PR TITLE
Fix build on OpenBSD

### DIFF
--- a/imagemetadata.cpp
+++ b/imagemetadata.cpp
@@ -18,7 +18,7 @@
 
 #include "imagemetadata.h"
 
-#ifdef Q_OS_LINUX
+#if defined(Q_OS_LINUX) || defined(Q_OS_OPENBSD)
 #include <exiv2/image.hpp>
 #endif
 


### PR DESCRIPTION
This won't affect the Mac OS X build.
Unfortunately the other BSDs will need their own Q_OS_\* define if they want this software too.
